### PR TITLE
Migrate S3 to S3Client

### DIFF
--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -38,14 +38,17 @@ export class GetS3Keys extends React.Component<Props>{
           bucketName: target.bucketName.value
       };
 
-      // const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey, awsS3Keys.bucketName);
-      // This doesn't work complete, it only prints success or failure to console
-      // const isValidUser = s3Auth.checkValidUser();
 
+      // Create a new S3Auth object with the user's keys
       let s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
       s3Auth.changeBucket(awsS3Keys.bucketName);
-      const isValidUser = s3Auth.checkValidUser();
-      console.log(isValidUser);
+      s3Auth.checkValidUser();
+      console.log(s3Auth.validUser);
+
+      let s3AuthFail = new MyS3Auth("badkey", "badkey");
+      s3AuthFail.changeBucket(awsS3Keys.bucketName);
+      s3AuthFail.checkValidUser();
+      console.log(s3AuthFail.validUser);
 
       // Following line should execute if a successful connection was made with S3, else change state to alert user of invalid keys
       // Change the UI to configure buckets after successful auth

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -1,7 +1,6 @@
 import React, {FormEvent} from 'react';
 import {render} from 'react-dom';
 import { MyS3Auth } from './aws_s3_auth_conn';
-import { MyS3Auth2 } from './aws_s3_auth_conn';
   
 
 // Stores the S3 keys from user input
@@ -43,11 +42,10 @@ export class GetS3Keys extends React.Component<Props>{
       // This doesn't work complete, it only prints success or failure to console
       // const isValidUser = s3Auth.checkValidUser();
 
-      try {
-        const s3ClientAuth = new MyS3Auth2(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
-      } catch (error) {
-        console.log(error);
-      }
+      let s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
+      s3Auth.changeBucket(awsS3Keys.bucketName);
+      const isValidUser = s3Auth.checkValidUser();
+      console.log(isValidUser);
 
       // Following line should execute if a successful connection was made with S3, else change state to alert user of invalid keys
       // Change the UI to configure buckets after successful auth

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -45,11 +45,13 @@ export class GetS3Keys extends React.Component<Props>{
       s3Auth.checkValidUser();
       console.log(s3Auth.validUser);
 
+      // Case where user's keys are invalid
       let s3AuthFail = new MyS3Auth("badkey", "badkey");
       s3AuthFail.changeBucket(awsS3Keys.bucketName);
       s3AuthFail.checkValidUser();
       console.log(s3AuthFail.validUser);
 
+      
       // Following line should execute if a successful connection was made with S3, else change state to alert user of invalid keys
       // Change the UI to configure buckets after successful auth
       this.props.onViewChange!('config-bucket');

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -1,6 +1,7 @@
 import React, {FormEvent} from 'react';
 import {render} from 'react-dom';
 import { MyS3Auth } from './aws_s3_auth_conn';
+import { MyS3Auth2 } from './aws_s3_auth_conn';
   
 
 // Stores the S3 keys from user input
@@ -38,9 +39,15 @@ export class GetS3Keys extends React.Component<Props>{
           bucketName: target.bucketName.value
       };
 
-      const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey, awsS3Keys.bucketName);
+      // const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey, awsS3Keys.bucketName);
       // This doesn't work complete, it only prints success or failure to console
-      const isValidUser = s3Auth.checkValidUser();
+      // const isValidUser = s3Auth.checkValidUser();
+
+      try {
+        const s3ClientAuth = new MyS3Auth2(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
+      } catch (error) {
+        console.log(error);
+      }
 
       // Following line should execute if a successful connection was made with S3, else change state to alert user of invalid keys
       // Change the UI to configure buckets after successful auth

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -1,11 +1,14 @@
 import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3"; // ES Modules import
 
 export class MyS3Auth {
+  // S3Client object
   s3Client:     S3Client
   validUser:    boolean
 
+  // S3Client parameters
   whichBucket:  string
   region:       string
+
 
   constructor (publicKey : string, privateKey : string, _region : string = "us-east-1") {
     if (publicKey.length === 0 || privateKey.length === 0) {
@@ -27,6 +30,8 @@ export class MyS3Auth {
     this.validUser = false
   }
 
+
+  // Change the user's keys
   changeUser(publicKey : string, privateKey : string) {
     if (publicKey.length === 0 || privateKey.length === 0) {
       throw new Error("Public and private keys cannot be empty")
@@ -41,6 +46,8 @@ export class MyS3Auth {
     this.validUser = false
   }
 
+
+  // Change the bucket name
   changeBucket(bucketName : string) {
     if (bucketName.length === 0) {
       throw new Error("Bucket name cannot be empty")
@@ -49,25 +56,19 @@ export class MyS3Auth {
     this.validUser = false
   }
 
-  changeRegion(region : string) {
-    if (region.length === 0) {
-      throw new Error("Region cannot be empty")
-    }
-    this.region = region
-    this.validUser = false
-  }
 
+  // Check if the user's keys are valid for specified bucket
   checkValidUser() {
     try {
       const headBucketCommand = new HeadBucketCommand({
         Bucket: this.whichBucket,
       })
       this.s3Client.send(headBucketCommand)
+      this.validUser = true
     } catch (err) {
       this.validUser = false
       console.log("Error", err)
     } finally {
-      this.validUser = true
       console.log("Finished checking user")
     }
   }

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -1,4 +1,32 @@
 import { S3 } from "aws-sdk"
+// import { S3 } from "@aws-sdk/client-s3"
+import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3"; // ES Modules import
+
+
+export class MyS3Auth2 {
+  s3Client:     S3Client
+  validUser:    boolean
+
+  whichBucket:  string
+
+  constructor (publicKey : string, privateKey : string, _bucketName : string = "", _region : string = "Global") {
+    if (publicKey.length === 0 || privateKey.length === 0) {
+      throw new Error("Public and private keys cannot be empty")
+    }
+    
+    this.s3Client = new S3Client({
+      credentials: {
+        accessKeyId: publicKey,
+        secretAccessKey: privateKey,
+      },
+      region: _region,
+    })
+
+    this.whichBucket = _bucketName
+    this.validUser = false
+  }
+
+}
 
 export class MyS3Auth {
   s3:           S3
@@ -40,7 +68,7 @@ export class MyS3Auth {
 
   async checkValidUser() : Promise<boolean> {
     try {
-      const res = await this.s3.headBucket({Bucket: this.whichBucket}).promise()
+      // const res = await this.s3.headBucket({Bucket: this.whichBucket}).promise()
       console.log("Successful")
       this.validUser = true
       return true

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -1,6 +1,4 @@
-// import { S3 } from "@aws-sdk/client-s3"
 import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3"; // ES Modules import
-
 
 export class MyS3Auth {
   s3Client:     S3Client
@@ -9,11 +7,12 @@ export class MyS3Auth {
   whichBucket:  string
   region:       string
 
-  constructor (publicKey : string, privateKey : string, _region : string = "Global") {
+  constructor (publicKey : string, privateKey : string, _region : string = "us-east-1") {
     if (publicKey.length === 0 || privateKey.length === 0) {
       throw new Error("Public and private keys cannot be empty")
     }
     
+    // Default region is us-east-1 (N. Virginia), needed for S3Client
     this.region = _region
 
     this.s3Client = new S3Client({
@@ -50,17 +49,26 @@ export class MyS3Auth {
     this.validUser = false
   }
 
-  checkValidUser() : boolean{
+  changeRegion(region : string) {
+    if (region.length === 0) {
+      throw new Error("Region cannot be empty")
+    }
+    this.region = region
+    this.validUser = false
+  }
+
+  checkValidUser() {
     try {
-      const command = new HeadBucketCommand({ Bucket: this.whichBucket })
-      const data = this.s3Client.send(command)
-      console.log("Success", data)
-      this.validUser = true
+      const headBucketCommand = new HeadBucketCommand({
+        Bucket: this.whichBucket,
+      })
+      this.s3Client.send(headBucketCommand)
     } catch (err) {
       this.validUser = false
       console.log("Error", err)
     } finally {
-      return this.validUser
+      this.validUser = true
+      console.log("Finished checking user")
     }
   }
 }

--- a/temp.mjs
+++ b/temp.mjs
@@ -1,0 +1,24 @@
+import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3";
+
+var client = new S3Client({ 
+    credentials: {
+        accessKeyId: "",
+        secretAccessKey: "",
+    },
+    region: "us-east-1",
+});
+
+const command = new HeadBucketCommand({ Bucket: "arc" });
+
+var resVal = null;
+
+try {
+    const data = await client.send(command);
+    console.log(data);
+    resVal = true;
+} catch (err) {
+    console.error(err);
+    resVal = false;
+} finally {
+    console.log("Done", resVal);
+}

--- a/temp.mjs
+++ b/temp.mjs
@@ -8,9 +8,28 @@ var client = new S3Client({
     region: "us-east-1",
 });
 
-const command = new HeadBucketCommand({ Bucket: "arc" });
+const command = new HeadBucketCommand({ Bucket: "" });
 
 var resVal = null;
+
+// client.send(command).then(
+//     (data) => {
+//         console.log(data);
+//         resVal = true;
+//     }).catch(
+//     (err) => {
+//         console.error(err);
+//         resVal = false;
+//     }).finally(() => {
+//         console.log("Done", resVal);
+// });
+
+// // console.log("after", resVal);    
+// while (resVal == null) {
+//     console.log("waiting");
+// }
+
+// console.log("after", resVal);
 
 try {
     const data = await client.send(command);
@@ -22,3 +41,5 @@ try {
 } finally {
     console.log("Done", resVal);
 }
+
+console.log("after", resVal);


### PR DESCRIPTION
Migration from S3 to S3Client has been finished.

Partially solves issue #25 as it changes the extension size from 3.4Mb to 0.7Mb. However, the warning that popup.js is too large still pops up.

S3Client also avoids potential deprecation issues from using S3. 

S3Client also has more documentation related to Promise features, which should make setting up issue #22 easier to solve in the future.