### PR TITLE
Globalize the S3 object made

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,32 +1,43 @@
 import React, {useState} from 'react';
 import {render} from 'react-dom';
 import {GetS3Keys} from './aws_s3_auth';
-
+import { MyS3Auth } from './aws_s3_auth_conn';
 
 // Type Props specifies a function that will change the state of App
-type Props = {onViewChange? : (s:string)=>void};
+type Props = {
+    onViewChange? : (s:string)=>void,
+    onS3ObjChange? : (o:MyS3Auth)=>void
+};
 
 // Type ViewState specifies the state (auth, bucket configuration, file upload display, etc)
-type ViewState = {
+type State = {
     view: string;
+    s3Obj: MyS3Auth | {};
 }
 
 // Driver for the UI
 // App will serve as the root node for the "tree" of different UIs. It will always render the "state" that is set by any sub function  
-export class App extends React.Component<Props, ViewState>{
+export class App extends React.Component<Props, State>{
 
     // Create the App, set props and default the state of App to render auth
     constructor(props:Props) {
         super(props);
-        this.handler = this.handler.bind(this)
+        this.setViewState = this.setViewState.bind(this);
+        this.setS3Obj = this.setS3Obj.bind(this)
         this.state = {
-            view: 'auth'
+            view: 'auth',
+            s3Obj: {}
         };
     }
 
-    // Function that will be passed as a prop to update the state
-    handler(view:string) {
+    // Function that will be passed as a prop to update the state of the UI
+    setViewState(view:string) {
         this.setState({view})
+    }
+
+    // Function that will be passed as prop to globalize the S3 Object being made
+    setS3Obj(s3Obj:MyS3Auth){
+        this.setState({s3Obj})
     }
     
     render() {
@@ -35,7 +46,8 @@ export class App extends React.Component<Props, ViewState>{
             {this.state.view === 'auth' 
             && 
             <GetS3Keys
-                onViewChange={this.handler}
+                onViewChange={this.setViewState}
+                onS3ObjChange = {this.setS3Obj}
             />}
             
             {this.state.view === 'config-bucket' 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,14 +11,6 @@ type ViewState = {
     view: string;
 }
 
-type accessKey = {
-    key: string;
-}
-
-type secretAccessKey = {
-    key: string;
-}
-
 // Driver for the UI
 // App will serve as the root node for the "tree" of different UIs. It will always render the "state" that is set by any sub function  
 export class App extends React.Component<Props, ViewState>{

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -16,7 +16,10 @@ interface AWSAuthForm extends HTMLFormElement {
 }
 
 // Type prop meant to be called with the identifier of the new state (UI) for App to render
-type Props = {onViewChange? : (v : string)=>void};
+type Props = {
+  onViewChange? : (s:string)=>void,
+  onS3ObjChange? : (o:MyS3Auth)=>void
+};
 
 export class GetS3Keys extends React.Component<Props>{
 
@@ -24,14 +27,14 @@ export class GetS3Keys extends React.Component<Props>{
     super(props);
   }
 
-  //function to connect to s3
+  // Function to connect to s3
   onSubmit = (event: FormEvent<AWSAuthForm>) => {
-      //Prevent Default so that the event can be recorded in console
+      // Prevent Default so that the event can be recorded in console
       event.preventDefault();
 
       const target = event.currentTarget.elements;
       
-      //User's keys for AWS S3
+      // User's keys for AWS S3
       const awsS3Keys = {
           accessKey: target.accessKey.value,
           secretAccessKey: target.secretAccessKey.value,
@@ -41,7 +44,10 @@ export class GetS3Keys extends React.Component<Props>{
       // Create a new S3Auth object with the user's keys
       const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
       s3Auth.changeBucket(awsS3Keys.bucketName);
-      s3Auth.checkAndDisplayValidUser(this.props.onViewChange!, 'config-bucket');
+
+      // Following function call will validate the user and only after validation will the S3 object be stored in app
+      s3Auth.checkAndDisplayValidUser(this.props.onViewChange!, 'config-bucket', this.props.onS3ObjChange!, s3Auth);
+      
   };
   
   render () {

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -38,14 +38,10 @@ export class GetS3Keys extends React.Component<Props>{
           bucketName: target.bucketName.value
       };
 
-
       // Create a new S3Auth object with the user's keys
       const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
       s3Auth.changeBucket(awsS3Keys.bucketName);
       s3Auth.checkAndDisplayValidUser(this.props.onViewChange!, 'config-bucket');
-
-
-      console.log("Something happened")
   };
   
   render () {

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -9,7 +9,6 @@ export class MyS3Auth {
   whichBucket:  string
   region:       string
 
-
   constructor (publicKey : string, privateKey : string, _region : string = "us-east-1") {
     if (publicKey.length === 0 || privateKey.length === 0) {
       throw new Error("Public and private keys cannot be empty")
@@ -29,7 +28,6 @@ export class MyS3Auth {
     this.whichBucket = ""
     this.validUser = false
   }
-
 
   // Change the user's keys
   changeUser(publicKey : string, privateKey : string) {
@@ -60,11 +58,11 @@ export class MyS3Auth {
 
   // Check if the user's keys are valid for specified bucket
   // Code after this function call will likely execute before this function finishes
-  checkAndDisplayValidUser(fnSucceed : (args : string) => any, args : string ) {
+  checkAndDisplayValidUser(setViewState : (args : string) => any, args : string ) {
     const command = new HeadBucketCommand({ Bucket: this.whichBucket })
     this.s3Client.send(command).then((data) => {
       console.log(data)
-      fnSucceed(args)
+      setViewState(args)
     }).catch((err) => {
       console.log(err)
     })

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -57,12 +57,15 @@ export class MyS3Auth {
   }
 
   // Check if the user's keys are valid for specified bucket
+  // Save the S3 object made upon validation
   // Code after this function call will likely execute before this function finishes
-  checkAndDisplayValidUser(setViewState : (args : string) => any, args : string ) {
+  checkAndDisplayValidUser(setViewState : (args : string) => any, args : string, setS3Obj : (s3Obj : MyS3Auth) => any, s3Obj : MyS3Auth ) {
+    
     const command = new HeadBucketCommand({ Bucket: this.whichBucket })
     this.s3Client.send(command).then((data) => {
-      console.log(data)
-      setViewState(args)
+      console.log(data);
+      setS3Obj(s3Obj);
+      setViewState(args);
     }).catch((err) => {
       console.log(err)
     })


### PR DESCRIPTION
This PR makes the S3 object made in auth global at the `app` level. Doing this will allow the object to be passed to sub-functions/classes for later feature development instead of remaking the objects for a connection. 

The S3 object is only globalized upon successful user authentication. 

PR resolves issue #20 

PR cleans up unneeded variables in `App.tsx` and makes var names more verbose in `auth_conn`