### PR TITLE
Rename the aws_s3_auth_conn class and its references

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,20 +1,20 @@
 import React, {useState} from 'react';
 import {render} from 'react-dom';
 import {GetS3Keys} from './aws_s3_auth';
-import { MyS3Auth } from './aws_s3_auth_conn';
+import { UserS3 } from './aws_s3_connect';
 import {ViewStateStorage} from './storage/store_view_state';
 import {UserMetaStorage} from './storage/store_user_metadata';
 
 // Type Props specifies a function that will change the state of App
 type Props = {
     onViewChange? : (s:string)=>void,
-    onS3ObjChange? : (o:MyS3Auth)=>void
+    onS3ObjChange? : (o:UserS3)=>void
 };
 
 // Type ViewState specifies the state (auth, bucket configuration, file upload display, etc)
 type State = {
     view: string;
-    s3Obj: MyS3Auth | null;
+    s3Obj: UserS3 | null;
 }
 
 // App will serve as the root node for the "tree" of different UIs. It will always render the "state" that is set by any sub function  
@@ -43,7 +43,7 @@ export class App extends React.Component<Props, State>{
     }
 
     // Function that will be passed as prop to globalize the S3 Object being made
-    setS3Obj(s3Obj:MyS3Auth | null){
+    setS3Obj(s3Obj:UserS3 | null){
 
         this.setState({s3Obj});
 
@@ -68,7 +68,7 @@ export class App extends React.Component<Props, State>{
         // Access keys could be undefined if chrome storage returns undefined for a key that doesn't exist
         if (accessKeyId !== undefined && secretAccessKey !== undefined && region !== undefined){
 
-            const s3Obj = new MyS3Auth(accessKeyId, secretAccessKey, region);
+            const s3Obj = new UserS3(accessKeyId, secretAccessKey, region);
             this.setS3Obj(s3Obj); 
         }
     }

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -1,5 +1,5 @@
 import React, {FormEvent} from 'react';
-import { MyS3Auth } from './aws_s3_auth_conn';
+import { UserS3 } from './aws_s3_connect';
   
 
 // Stores the S3 keys from user input
@@ -17,7 +17,7 @@ interface AWSAuthForm extends HTMLFormElement {
 // Type prop meant to be called with the identifier of the new state (UI) for App to render
 type Props = {
   onViewChange? : (s:string)=>void,
-  onS3ObjChange? : (o:MyS3Auth)=>void
+  onS3ObjChange? : (o:UserS3)=>void
 };
 
 export class GetS3Keys extends React.Component<Props>{
@@ -41,7 +41,7 @@ export class GetS3Keys extends React.Component<Props>{
       };
 
       // Create a new S3Auth object with the user's keys
-      const s3Auth = new MyS3Auth(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
+      const s3Auth = new UserS3(awsS3Keys.accessKey, awsS3Keys.secretAccessKey);
 
       // Following function call will validate the user and only after validation will the S3 object be stored in app
       s3Auth.checkAndDisplayValidUser(this.props.onViewChange!, 'config-bucket', this.props.onS3ObjChange!, s3Auth);

--- a/src/aws_s3_config_bucket.tsx
+++ b/src/aws_s3_config_bucket.tsx
@@ -1,5 +1,5 @@
 import React, {FormEvent} from 'react';
-import { MyS3Auth } from './aws_s3_auth_conn';
+import { UserS3 } from './aws_s3_connect';
 
 
 // Stores the Bucket name from user input
@@ -16,8 +16,8 @@ interface BucketNameForm extends HTMLFormElement {
 // Type prop meant to be called with the identifier of the new state (UI) for App to render
 type Props = {
   onViewChange? : (s:string)=>void,
-  onS3ObjChange? : (o:MyS3Auth)=>void,
-  existingS3Obj?: MyS3Auth
+  onS3ObjChange? : (o:UserS3)=>void,
+  existingS3Obj?: UserS3
 };
 
 export class BucketConfigurator extends React.Component<Props>{

--- a/src/aws_s3_connect.tsx
+++ b/src/aws_s3_connect.tsx
@@ -1,14 +1,14 @@
 import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3"; // ES Modules import
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 
-export class MyS3Auth {
+export class UserS3 {
   // S3Client and STSClient object
   private s3Client:     S3Client
   private stsClient:    STSClient
   private accessKeyId: string
   private secretAccessKey: string
 
-  // MyS3Auth object properties
+  // UserS3 object properties
   validUser:    boolean
   validBucket:  boolean
   whichBucket:  string
@@ -103,7 +103,7 @@ export class MyS3Auth {
   // Check if the user's keys are valid for specified bucket
   // Save the S3 object made upon validation
   // Code after this function call will likely execute before this function finishes
-  checkAndDisplayValidBucket(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : MyS3Auth) => void, s3Obj : MyS3Auth ) {
+  checkAndDisplayValidBucket(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : UserS3) => void, s3Obj : UserS3 ) {
     
     const command = new HeadBucketCommand({ Bucket: this.whichBucket })
     this.s3Client.send(command).then((data) => {
@@ -119,7 +119,7 @@ export class MyS3Auth {
 
   // Check if the user's keys are valid
   // Code after this function call will likely execute before this function finishes
-  checkAndDisplayValidUser(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : MyS3Auth) => void, s3Obj : MyS3Auth ) {
+  checkAndDisplayValidUser(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : UserS3) => void, s3Obj : UserS3 ) {
     const command = new GetCallerIdentityCommand({})
     this.stsClient.send(command).then((data) => {
       setS3Obj(s3Obj);

--- a/src/storage/store_user_metadata.ts
+++ b/src/storage/store_user_metadata.ts
@@ -1,4 +1,4 @@
-import { MyS3Auth } from '../aws_s3_auth_conn';
+import { UserS3 } from '../aws_s3_connect';
 
 const ACCESS_KEY_ID_KEY = 'publicKey';
 const SECRET_ACCESS_KEY_KEY = 'privateKey';
@@ -6,7 +6,7 @@ const REGION_KEY = 'region';
 
 export class UserMetaStorage {
 
-    static putUserS3Obj(user:MyS3Auth){
+    static putUserS3Obj(user:UserS3){
         // This function adds all user metadata to storage
 
         const accessKeyId = user._accessKeyId;

--- a/test/aws_s3_connect.test.tsx
+++ b/test/aws_s3_connect.test.tsx
@@ -1,10 +1,10 @@
-import {MyS3Auth} from "../src/aws_s3_auth_conn";
+import {UserS3} from "../src/aws_s3_connect";
 
 describe("Validate successful bucket change", () => {
   test("Change User's S3 bucket", () => {
 
     // Construct S3 Auth object
-    let s = new MyS3Auth("test", "test");
+    let s = new UserS3("test", "test");
     expect(s.changeBucket("bucket")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Renamed aws_s3_auth_conn file to aws_s3_connect. Renamed the class and the variable names of objects referencing it. The new name is more true to the purpose of the class.

Unit tests pass and the build is successful with the expected functionality