### PR TITLE
14 configure a users s3 bucket as the destination for file transfer

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -101,19 +101,21 @@ export class App extends React.Component<Props, State>{
             
             {this.state.view === 'config-bucket' 
             && 
-            
-            <div> 
-                Configure the bucket
-                <div id="logout">
-                    <button
-                        type="button" 
-                        value="Logout"
-                        onClick={this.logout}
-                    >
-                        Logout
-                    </button>
-                </div>
-            </div>}
+            <div>
+                <BucketConfigurator
+                    onS3ObjChange={this.setS3Obj}
+                    onViewChange={this.setViewState}
+                    existingS3Obj={this.state.s3Obj!}
+                />
+                <button
+                    type="button" 
+                    value="Logout"
+                    onClick={this.logout}
+                >
+                    Logout
+                </button>
+            </div>
+            }
         </div>
         )
     }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import {GetS3Keys} from './aws_s3_auth';
 import { MyS3Auth } from './aws_s3_auth_conn';
 import {ViewStateStorage} from './storage/store_view_state';
 import {UserMetaStorage} from './storage/store_user_metadata';
+import {BucketConfigurator} from './aws_s3_bucket_front';
 
 // Type Props specifies a function that will change the state of App
 type Props = {
@@ -100,6 +101,7 @@ export class App extends React.Component<Props, State>{
             
             {this.state.view === 'config-bucket' 
             && 
+            
             <div> 
                 Configure the bucket
                 <div id="logout">

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -116,6 +116,20 @@ export class App extends React.Component<Props, State>{
                 </button>
             </div>
             }
+
+            {this.state.view === 'temp-window'
+            &&
+            <div>
+                <h1>Temp Window</h1>
+                <button
+                    type="button" 
+                    value="Logout"
+                    onClick={this.logout}
+                >
+                    Reset for Testing
+                </button>
+            </div>
+            }
         </div>
         )
     }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import {GetS3Keys} from './aws_s3_auth';
 import { MyS3Auth } from './aws_s3_auth_conn';
 import {ViewStateStorage} from './storage/store_view_state';
 import {UserMetaStorage} from './storage/store_user_metadata';
-import {BucketConfigurator} from './aws_s3_bucket_front';
+import {BucketConfigurator} from './aws_s3_config_bucket';
 
 // Type Props specifies a function that will change the state of App
 type Props = {

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -6,7 +6,7 @@ import { MyS3Auth } from './aws_s3_auth_conn';
 interface AWS3Keys extends HTMLFormControlsCollection {
   accessKey: HTMLInputElement;
   secretAccessKey: HTMLInputElement;
-  bucketName: HTMLInputElement;
+  // bucketName: HTMLInputElement;
 }
 
 // Make the param for onSubmit of type readonly 
@@ -37,7 +37,7 @@ export class GetS3Keys extends React.Component<Props>{
       const awsS3Keys = {
           accessKey: target.accessKey.value,
           secretAccessKey: target.secretAccessKey.value,
-          bucketName: target.bucketName.value
+          // bucketName: target.bucketName.value
       };
 
       // Create a new S3Auth object with the user's keys
@@ -71,16 +71,6 @@ export class GetS3Keys extends React.Component<Props>{
                 <input 
                   type="password" 
                   id="secretAccessKey"
-                />
-            </div>
-            <div className="field">
-                <div id="keyLabels">
-                  <label htmlFor="bucketName">AWS S3 Bucket Name</label>
-                </div>
-
-                <input
-                  type="text"
-                  id="bucketName"
                 />
             </div>
             <div id="authSubmit">

--- a/src/aws_s3_auth.tsx
+++ b/src/aws_s3_auth.tsx
@@ -6,7 +6,6 @@ import { MyS3Auth } from './aws_s3_auth_conn';
 interface AWS3Keys extends HTMLFormControlsCollection {
   accessKey: HTMLInputElement;
   secretAccessKey: HTMLInputElement;
-  // bucketName: HTMLInputElement;
 }
 
 // Make the param for onSubmit of type readonly 
@@ -37,7 +36,6 @@ export class GetS3Keys extends React.Component<Props>{
       const awsS3Keys = {
           accessKey: target.accessKey.value,
           secretAccessKey: target.secretAccessKey.value,
-          // bucketName: target.bucketName.value
       };
 
       // Create a new S3Auth object with the user's keys

--- a/src/aws_s3_auth_conn.tsx
+++ b/src/aws_s3_auth_conn.tsx
@@ -103,7 +103,7 @@ export class MyS3Auth {
   // Check if the user's keys are valid for specified bucket
   // Save the S3 object made upon validation
   // Code after this function call will likely execute before this function finishes
-  checkAndDisplayValidBucket(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : MyS3Auth) => void, s3Obj : MyS3Auth ) {
+  checkBucketAndChangeUI(setViewState : (args : string) => void, args : string, setS3Obj : (s3Obj : MyS3Auth) => void, s3Obj : MyS3Auth ) {
     
     const command = new HeadBucketCommand({ Bucket: this.whichBucket })
     this.s3Client.send(command).then((data) => {

--- a/src/aws_s3_bucket_front.tsx
+++ b/src/aws_s3_bucket_front.tsx
@@ -1,0 +1,44 @@
+import React, {FormEvent} from 'react';
+import { MyS3Auth } from './aws_s3_auth_conn';
+
+
+// Stores the Bucket name from user input
+interface BucketName extends HTMLFormControlsCollection {
+    bucketName: HTMLInputElement;
+}
+
+
+// Make the param for onSubmit of type readonly
+interface BucketNameForm extends HTMLFormElement {
+    readonly elements: BucketName;
+}
+
+// Type prop meant to be called with the identifier of the new state (UI) for App to render
+type Props = {
+  onViewChange? : (s:string)=>void,
+  onS3ObjChange? : (o:MyS3Auth)=>void,
+  existingS3Obj: MyS3Auth
+};
+
+export class BucketConfigurator extends React.Component<Props>{
+
+    constructor(props:Props){
+        super(props);
+    }
+
+    // Function to configure the bucket
+    onSubmit = (event: FormEvent<BucketNameForm>) => {
+        // Prevent Default so that the event can be recorded in console
+        event.preventDefault();
+
+        const target = event.currentTarget.elements;
+
+        // User's keys for AWS S3
+        const bucketName = target.bucketName.value;
+
+        // Reuse the S3 object from App
+
+    };
+
+
+}

--- a/src/aws_s3_bucket_front.tsx
+++ b/src/aws_s3_bucket_front.tsx
@@ -17,7 +17,7 @@ interface BucketNameForm extends HTMLFormElement {
 type Props = {
   onViewChange? : (s:string)=>void,
   onS3ObjChange? : (o:MyS3Auth)=>void,
-  existingS3Obj: MyS3Auth
+  existingS3Obj?: MyS3Auth
 };
 
 export class BucketConfigurator extends React.Component<Props>{
@@ -37,8 +37,32 @@ export class BucketConfigurator extends React.Component<Props>{
         const bucketName = target.bucketName.value;
 
         // Reuse the S3 object from App
+        const s3Auth = this.props.existingS3Obj;
 
+        // Configure the bucket
+        // s3Auth.changeBucket(bucketName);
     };
 
+    render () {
+        return(
+            <form className="form" onSubmit={this.onSubmit}>
+                <div id="welcomeMessage">
+                    <h1>Access your bucket</h1>
+                </div>
+                <div className="field">
+                    <div id="keyLabels">
+                        <label htmlFor="bucketName">AWS S3 Bucket Name</label>
+                    </div>
 
+                    <input
+                        type="text"
+                        id="bucketName"
+                    />
+                </div>
+                <div id="bucketButton">
+                    <button type="submit">Submit</button>
+                </div>
+            </form>
+        )
+    }
 }

--- a/src/aws_s3_bucket_front.tsx
+++ b/src/aws_s3_bucket_front.tsx
@@ -1,5 +1,7 @@
 import React, {FormEvent} from 'react';
 import { MyS3Auth } from './aws_s3_auth_conn';
+import {ViewStateStorage} from './storage/store_view_state';
+import {UserMetaStorage} from './storage/store_user_metadata';
 
 
 // Stores the Bucket name from user input
@@ -35,9 +37,10 @@ export class BucketConfigurator extends React.Component<Props>{
 
         // User's keys for AWS S3
         const bucketName = target.bucketName.value;
+        console.log(bucketName);
 
         // Reuse the S3 object from App
-        const s3Auth = this.props.existingS3Obj;
+        // const s3Auth = this.props.existingS3Obj;
 
         // Configure the bucket
         // s3Auth.changeBucket(bucketName);

--- a/src/aws_s3_bucket_front.tsx
+++ b/src/aws_s3_bucket_front.tsx
@@ -1,7 +1,5 @@
 import React, {FormEvent} from 'react';
 import { MyS3Auth } from './aws_s3_auth_conn';
-import {ViewStateStorage} from './storage/store_view_state';
-import {UserMetaStorage} from './storage/store_user_metadata';
 
 
 // Stores the Bucket name from user input
@@ -37,13 +35,13 @@ export class BucketConfigurator extends React.Component<Props>{
 
         // User's keys for AWS S3
         const bucketName = target.bucketName.value;
-        console.log(bucketName);
 
         // Reuse the S3 object from App
-        // const s3Auth = this.props.existingS3Obj;
+        const s3Auth = this.props.existingS3Obj!;
 
         // Configure the bucket
-        // s3Auth.changeBucket(bucketName);
+        s3Auth.changeBucket(bucketName);
+        s3Auth.checkAndDisplayValidBucket(this.props.onViewChange!, 'temp-window', this.props.onS3ObjChange!, s3Auth);
     };
 
     render () {

--- a/src/aws_s3_config_bucket.tsx
+++ b/src/aws_s3_config_bucket.tsx
@@ -33,7 +33,7 @@ export class BucketConfigurator extends React.Component<Props>{
 
         const target = event.currentTarget.elements;
 
-        // User's keys for AWS S3
+        // User's selected bucket name
         const bucketName = target.bucketName.value;
 
         // Reuse the S3 object from App
@@ -41,17 +41,17 @@ export class BucketConfigurator extends React.Component<Props>{
 
         // Configure the bucket
         s3Auth.changeBucket(bucketName);
-        s3Auth.checkAndDisplayValidBucket(this.props.onViewChange!, 'temp-window', this.props.onS3ObjChange!, s3Auth);
+        s3Auth.checkBucketAndChangeUI(this.props.onViewChange!, 'temp-window', this.props.onS3ObjChange!, s3Auth);
     };
 
     render () {
         return(
             <form className="form" onSubmit={this.onSubmit}>
-                <div id="welcomeMessage">
+                <div id="bucketMessage">
                     <h1>Access your bucket</h1>
                 </div>
                 <div className="field">
-                    <div id="keyLabels">
+                    <div id="bucketNme">
                         <label htmlFor="bucketName">AWS S3 Bucket Name</label>
                     </div>
 


### PR DESCRIPTION
This splits the original window into 2 windows.

The login window looks like this now.
![image](https://user-images.githubusercontent.com/70293835/222931983-be378122-f29c-4cd4-95f7-ebc98d02f715.png)

If a successful login happen it goes to this window, they'll still have the option to log out from here.
![image](https://user-images.githubusercontent.com/70293835/222932021-629b096a-b0a5-411a-b43e-fd9635dfe351.png)

If a bucket exists that the user has access to then it'll go to this window.
![image](https://user-images.githubusercontent.com/70293835/222932075-a9c5b79d-35dc-4a18-87c6-96d9c2c82aa2.png)

Right now I just made a simple temporary window, but to reset everything it's the same thing as logging out. So when doing some test the extension doesn't get stuck in one of the windows.

PR resolves #14 