### PR TITLE
Fix viewState caching bug

### DIFF
--- a/src/storage/store_view_state.ts
+++ b/src/storage/store_view_state.ts
@@ -5,14 +5,14 @@ export class ViewStateStorage {
     static putViewState(value:string){
         // This function adds the key:value => VIEW_STATE_KEY:'ui state' to storage
 
-        chrome.storage.local.set({ [VIEW_STATE_KEY]: value });
+        chrome.storage.session.set({ [VIEW_STATE_KEY]: value });
     }
     
     static getViewState(onGetStorageKeyValue:(s:string)=>void){
         // This function gets the stored view state from chrome's storage
         // The param is a function which sets the state, it acts like call back
 
-        chrome.storage.local.get([VIEW_STATE_KEY], function(result) {
+        chrome.storage.session.get([VIEW_STATE_KEY], function(result) {
            onGetStorageKeyValue(result[VIEW_STATE_KEY]);
         });
     }
@@ -20,7 +20,7 @@ export class ViewStateStorage {
     static removeViewState(onGetStorageKeyValue:()=>void){
         // This function removes view state from chrome's storage
 
-        chrome.storage.local.remove([VIEW_STATE_KEY], function() {
+        chrome.storage.session.remove([VIEW_STATE_KEY], function() {
             onGetStorageKeyValue();
         });
     }


### PR DESCRIPTION
This PR fixes a bug caused by the viewState being cached in the browser. A new build should've ideally made the extension render the auth UI. The initial check in the App class constructor to see if viewState existed in storage should've been false and not modified viewState since the extension was newly built.

Expected behavior: Any time the application is built/rebuilt, the viewState should be cleared from storage (not just by logging out) and result in the auth UI to popup when the extension is opened. 

Why this didn't happen: The issue was that viewState was actually never being cleared from storage since it was cached "independently" from the application. This made the constructor in App class set viewState to an outdated state.

New modifications fix this bug and make sure the viewState only exists in storage as long as the session is alive. 

To test: build the application, enter valid keys to shift to the bucket config UI, rebuild the application, reload the extension and you should see the extension render the auth UI instead of the bucket config UI. 