### PR TITLE
Restructure callback and bucket verification

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import {GetS3Keys} from './aws_s3_auth';
 import { UserS3 } from './aws_s3_connect';
 import {ViewStateStorage} from './storage/store_view_state';
 import {UserMetaStorage} from './storage/store_user_metadata';
-import {BucketConfigurator} from './aws_s3_config_bucket';
+import {ConfigureBucket} from './aws_s3_config_bucket';
 import {FileTransfer} from './aws_s3_file_transfer';
 
 
@@ -106,7 +106,7 @@ export class App extends React.Component<Props, State>{
             {this.state.view === 'config-bucket' 
             && 
             <div>
-                <BucketConfigurator
+                <ConfigureBucket
                     onS3ObjChange={this.setS3Obj}
                     onViewChange={this.setViewState}
                     existingS3Obj={this.state.s3Obj!}

--- a/src/aws_s3_connect.tsx
+++ b/src/aws_s3_connect.tsx
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/client-s3"; // ES Modules import
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 import axios from "axios";
+import {UpdateStateMeta} from './aws_s3_config_bucket';
 
 export class UserS3 {
   // S3Client and STSClient object
@@ -106,25 +107,21 @@ export class UserS3 {
     this.whichBucket = bucketName;
     this.validUser = false;
 
-    // Returning true for unit tests
     return true;
   }
 
   // Check if the user's keys are valid for specified bucket
   // Save the S3 object made upon validation
-  // Code after this function call will likely execute before this function finishes
   checkBucketAndChangeUI(
-    setViewState: (args: string) => void,
-    args: string,
-    setS3Obj: (s3Obj: UserS3) => void,
-    s3Obj: UserS3
+    stateMeta: UpdateStateMeta,
+    callback: (stateMeta:UpdateStateMeta) => boolean,
   ) {
     const command = new HeadBucketCommand({ Bucket: this.whichBucket });
     this.s3Client
       .send(command)
       .then((data) => {
-        setS3Obj(s3Obj);
-        setViewState(args);
+
+        callback(stateMeta);
         this.validBucket = true;
       })
       .catch((err) => {


### PR DESCRIPTION
This PR changes the input for `checkBucketAndChangeUI` to accept an object and a callback for state updates. Defining the callback function will allow testing it to be easier than if its functionality was written in its caller promise function. It will also make it accessible in more contexts than just the caller function.

Unit test will come later