### PR TITLE
Right click file transfer

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -3,22 +3,18 @@ import { URLStorage } from "./storage/store_url_array";
 
 const VIEW_STATE_KEY = 'viewState';
 
+
+
 //Creates a Context Menu right click option for saving pdf links
-chrome.storage.session.get([VIEW_STATE_KEY], function(result) {
-    let viewState = result[VIEW_STATE_KEY];
-    if(viewState === 'file-transfer')
-    {
-        chrome.contextMenus.removeAll(function() {
-            chrome.contextMenus.create({
-                id: "rightclickoption",
-                title: "Send with Uplink",
-                contexts:["link"],
-               });
-        });
-    }
+chrome.contextMenus.removeAll(function() {
+    chrome.contextMenus.create({
+        id: "rightclickoption",
+        title: "Send with Uplink",
+        contexts:["link"],
+        visible:false,
+    });
 });
 
-//Listener for right click option that stores the link in memory
 chrome.contextMenus.onClicked.addListener(function(info,tab){
     let link:string = info.linkUrl as string;
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,13 +1,21 @@
 import React from "react";
 import { URLStorage } from "./storage/store_url_array";
 
+const VIEW_STATE_KEY = 'viewState';
+
 //Creates a Context Menu right click option for saving pdf links
-chrome.contextMenus.removeAll(function() {
-    chrome.contextMenus.create({
-        id: "rightclickoption",
-        title: "Send with Uplink",
-        contexts:["link"],
-       });
+chrome.storage.session.get([VIEW_STATE_KEY], function(result) {
+    let viewState = result[VIEW_STATE_KEY];
+    if(viewState === 'file-transfer')
+    {
+        chrome.contextMenus.removeAll(function() {
+            chrome.contextMenus.create({
+                id: "rightclickoption",
+                title: "Send with Uplink",
+                contexts:["link"],
+               });
+        });
+    }
 });
 
 //Listener for right click option that stores the link in memory

--- a/src/storage/store_view_state.ts
+++ b/src/storage/store_view_state.ts
@@ -5,6 +5,16 @@ export class ViewStateStorage {
     static putViewState(value:string){
         // This function adds the key:value => VIEW_STATE_KEY:'ui state' to storage
         chrome.storage.session.set({ [VIEW_STATE_KEY]: value });
+        if(value === 'file-transfer') {
+            chrome.contextMenus.update('rightclickoption', {
+                visible: true
+            });
+        }
+        else {
+            chrome.contextMenus.update('rightclickoption', {
+                visible: false
+            });
+        }
     }
     
     static getViewState(onGetStorageKeyValue:(s:string)=>void){


### PR DESCRIPTION
-updates the putView storage function to also update the chrome context menu
-removes visibility of right click option if the value of view being set to anything other than 'file-transfer' and adds if not

one alternative is to enable and disable the right click option instead - if not in file transfer, the option will be faint and unable to be clicked on
