### PR TITLE
58 font changes

### DIFF
--- a/font-changer.py
+++ b/font-changer.py
@@ -4,7 +4,6 @@ import os
 
 file_to_change = "src/index.html"
 
-output_file = file_to_change
 
 if len(sys.argv) < 2:
     os.exit(1)
@@ -20,10 +19,6 @@ for m in matches:
     # if m is a font replace it with the font chosen
     text = text.replace('font-family: \"%s\"' % m, 'font-family: \"%s\"' % font_chosen)
     
-# flag -t if you don't want to change the original file
-if '-t' in sys.argv:
-    output_file = "src/test.html"
-    
-with open(output_file, "w") as f:
+with open(file_to_change, "w") as f:
     f.write(text)
 

--- a/font-changer.py
+++ b/font-changer.py
@@ -4,7 +4,7 @@ import os
 
 file_to_change = "src/index.html"
 
-output_file = "src/test.html"
+output_file = file_to_change
 
 if len(sys.argv) < 2:
     os.exit(1)
@@ -20,9 +20,9 @@ for m in matches:
     # if m is a font replace it with the font chosen
     text = text.replace('font-family: \"%s\"' % m, 'font-family: \"%s\"' % font_chosen)
     
-# flag -o to overwrite the original file
-if '-o' in sys.argv:
-    output_file = file_to_change
+# flag -t if you don't want to change the original file
+if '-t' in sys.argv:
+    output_file = "src/test.html"
     
 with open(output_file, "w") as f:
     f.write(text)

--- a/font-changer.py
+++ b/font-changer.py
@@ -8,7 +8,8 @@ file_to_change = "src/index.html"
 if len(sys.argv) < 2:
     os.exit(1)
     
-font_chosen = sys.argv[1]
+# Acconts for fonts with multiple words
+font_chosen = " ".join(sys.argv[1:])
 
 text = open(file_to_change).read()  # read the entire file content
 

--- a/font-changer.py
+++ b/font-changer.py
@@ -1,0 +1,29 @@
+import sys
+import re
+import os
+
+file_to_change = "src/index.html"
+
+output_file = "src/test.html"
+
+if len(sys.argv) < 2:
+    os.exit(1)
+    
+font_chosen = sys.argv[1]
+
+text = open(file_to_change).read()  # read the entire file content
+
+
+
+matches = re.findall(r'\"(.+?)\"',text)  # match text between two quotes
+for m in matches:
+    # if m is a font replace it with the font chosen
+    text = text.replace('font-family: \"%s\"' % m, 'font-family: \"%s\"' % font_chosen)
+    
+# flag -o to overwrite the original file
+if '-o' in sys.argv:
+    output_file = file_to_change
+    
+with open(output_file, "w") as f:
+    f.write(text)
+

--- a/misc/font-changer.py
+++ b/misc/font-changer.py
@@ -1,12 +1,12 @@
 import sys
 import re
-import os
 
-file_to_change = "src/index.html"
+file_to_change = "../src/index.html"
 
 
 if len(sys.argv) < 2:
-    os.exit(1)
+    print("Usage: font-changer.py <font_name>")
+    sys.exit(1)
     
 # Acconts for fonts with multiple words
 font_chosen = " ".join(sys.argv[1:])

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
             cursor: pointer;
             transition-duration: 0.4s;
             font-size: 16px;
-            font-family: "Monaco"
+            font-family: "Verdana"
         }
 
         button:hover {
@@ -79,7 +79,7 @@
         #logoutButton:hover, #goBackButton:hover {
             background-color: rgb(174, 185, 185);
             color: black;
-            font-family: "Monaco"
+            font-family: "Verdana"
         }
 
         #welcomeMessage {
@@ -87,7 +87,7 @@
             justify-content: center;
             margin: 0 auto;
             color: rgb(22, 27, 51);
-            font-family: "Monaco";
+            font-family: "Verdana";
             padding-top: 15px;
             padding-bottom: 15px;
             font-size:17px;
@@ -98,7 +98,7 @@
         #subHeader{
             margin-left: 8px;
             color: rgb(60, 142, 153);
-            font-family: "Monaco";
+            font-family: "Verdana";
         }
 
         #authMessage, #bucketMessage, #sendFilesHeader {
@@ -106,7 +106,7 @@
             justify-content: center;
             margin: 0 auto;
             color: rgb(22, 27, 51);            
-            font-family: "Monaco"
+            font-family: "Verdana"
         }
         
         #keyLabels, #fileLabel, #bucketLabel {
@@ -149,7 +149,7 @@
         }
         
         #getStarted{
-            font-family: "Monaco";
+            font-family: "Verdana";
             color: rgb(60, 142, 153);
             margin-left: 8px;
         }

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
             cursor: pointer;
             transition-duration: 0.4s;
             font-size: 16px;
-            font-family: "Verdana"
+            font-family: "Monaco"
         }
 
         button:hover {
@@ -79,7 +79,7 @@
         #logoutButton:hover, #goBackButton:hover {
             background-color: rgb(174, 185, 185);
             color: black;
-            font-family: "Verdana"
+            font-family: "Monaco"
         }
 
         #welcomeMessage {
@@ -87,7 +87,7 @@
             justify-content: center;
             margin: 0 auto;
             color: rgb(22, 27, 51);
-            font-family: "Verdana";
+            font-family: "Monaco";
             padding-top: 15px;
             padding-bottom: 15px;
             font-size:17px;
@@ -98,7 +98,7 @@
         #subHeader{
             margin-left: 8px;
             color: rgb(60, 142, 153);
-            font-family: "Verdana";
+            font-family: "Monaco";
         }
 
         #authMessage, #bucketMessage, #sendFilesHeader {
@@ -106,7 +106,7 @@
             justify-content: center;
             margin: 0 auto;
             color: rgb(22, 27, 51);            
-            font-family: "Verdana"
+            font-family: "Monaco";
         }
         
         #keyLabels, #fileLabel, #bucketLabel {
@@ -149,7 +149,7 @@
         }
         
         #getStarted{
-            font-family: "Verdana";
+            font-family: "Monaco";
             color: rgb(60, 142, 153);
             margin-left: 8px;
         }


### PR DESCRIPTION
Old font was Monoca, which was a safe CSS so it would look different for different OS. The font has been changed to Verdana.

I also added a simple python script that allows font changes to be done quickly.
`python3 font-changer.py <font> -o`, -o is if you want to have you changes override the html

Here are before screenshots on a linux environment (ubuntu 22.04)
![Screenshot from 2023-04-03 15-33-14](https://user-images.githubusercontent.com/70293835/229631575-20db0198-b7e4-42b2-932b-8dceed78fc5d.png)
![Screenshot from 2023-04-03 15-34-55](https://user-images.githubusercontent.com/70293835/229631580-e99a0314-1edf-476b-9c10-a65a69fcef30.png)
![Screenshot from 2023-04-03 15-35-11](https://user-images.githubusercontent.com/70293835/229631583-195ac0a5-8277-403e-a571-e1a97fb8a4ea.png)
![Screenshot from 2023-04-03 15-39-21](https://user-images.githubusercontent.com/70293835/229631590-301a8a10-6a86-4767-bef8-da7c313e9c11.png)


Screenshots of changes after
![Screenshot from 2023-04-03 16-12-41](https://user-images.githubusercontent.com/70293835/229631650-35f27484-0f81-4ffe-b859-db1a23a4dd3f.png)
![Screenshot from 2023-04-03 16-13-37](https://user-images.githubusercontent.com/70293835/229631658-d1714e57-235d-4b4f-a94a-d3b2d5dba59e.png)
![Screenshot from 2023-04-03 16-14-12](https://user-images.githubusercontent.com/70293835/229631662-6de02557-e6fc-4e9f-b4a2-3ec90c191037.png)
![Screenshot from 2023-04-03 16-14-45](https://user-images.githubusercontent.com/70293835/229631664-7e6987d8-d73f-4c1b-b43e-306a02614a3a.png)
