### PR TITLE
Add persistence to file transfer ui

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,7 @@ type Props = {
 type State = {
     view: string;
     s3Obj: UserS3 | null;
-    urlArray: Array<string>;
+    urlArray: Array<string> | null;
 }
 
 // App will serve as the root node for the "tree" of different UIs. It will always render the "state" that is set by any sub function  
@@ -33,6 +33,7 @@ export class App extends React.Component<Props, State>{
         this.setViewState = this.setViewState.bind(this);
         this.setS3Obj = this.setS3Obj.bind(this);
         this.setURLArray = this.setURLArray.bind(this);
+        this.addURL = this.addURL.bind(this);
         this.state = {
             view: 'welcome',
             s3Obj: null,
@@ -40,9 +41,9 @@ export class App extends React.Component<Props, State>{
         };
 
         // "Reconstruct" the App object if necessary
-        ViewStateStorage.getViewState(this.updateViewStatefromStorage);
         UserMetaStorage.getUserS3Obj(this.updateS3ObjFromStorage);
         URLStorage.getURLArray(this.updateURLArrayfromStorage);
+        ViewStateStorage.getViewState(this.updateViewStatefromStorage);
     }
 
     // Function that will be passed as a prop to update the state of the UI
@@ -64,22 +65,21 @@ export class App extends React.Component<Props, State>{
     }
 
     // Function that will be passed as prop to update the URL Array
-    setURLArray(urlArray:Array<string>) {
+    setURLArray(urlArray:Array<string> | null) {
         if(urlArray){
             this.setState({urlArray});
-
-            for(var url of urlArray) {
-                URLStorage.putURL(url);
-            }
         }
     }
 
     // Adds a singular URL to state and storage
     // Doesn't rely on setURLArray b/c that function can lead to duplicate writes in storage
-    addUrl(url:string){
+    addURL(url:string){
         const callback = (urlArray:Array<string>) => {
-            urlArray.push(url);
-            this.setState({urlArray});
+            if(urlArray){     
+                urlArray.push(url);
+                this.setState({urlArray});
+            } 
+
             URLStorage.putURL(url);
         }
 
@@ -199,7 +199,7 @@ export class App extends React.Component<Props, State>{
                     onS3ObjChange={this.setS3Obj}
                     onViewChange={this.setViewState}
                     existingS3Obj={this.state.s3Obj!}
-                    onAddURL={this.addUrl}
+                    onAddURL={this.addURL}
                     existingURLArray={this.state.urlArray!}
                 />                
                 <div id="logout">

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ type Props = {
     onViewChange? : (s:string)=>void,
     onS3ObjChange? : (o:UserS3)=>void,
     onURLArrayChange? : (a:Array<string>)=>void
+    onAddURL? : (u:string)=>void
 };
 
 // Type ViewState specifies the state (auth, bucket configuration, file upload display, etc)
@@ -64,13 +65,25 @@ export class App extends React.Component<Props, State>{
 
     // Function that will be passed as prop to update the URL Array
     setURLArray(urlArray:Array<string>) {
-        if(urlArray)
-        {
+        if(urlArray){
             this.setState({urlArray});
+
             for(var url of urlArray) {
                 URLStorage.putURL(url);
             }
         }
+    }
+
+    // Adds a singular URL to state and storage
+    // Doesn't rely on setURLArray b/c that function can lead to duplicate writes in storage
+    addUrl(url:string){
+        const callback = (urlArray:Array<string>) => {
+            urlArray.push(url);
+            this.setState({urlArray});
+            URLStorage.putURL(url);
+        }
+
+        URLStorage.getURLArray(callback);
     }
 
     // Changes the view state from what is in storage
@@ -186,6 +199,8 @@ export class App extends React.Component<Props, State>{
                     onS3ObjChange={this.setS3Obj}
                     onViewChange={this.setViewState}
                     existingS3Obj={this.state.s3Obj!}
+                    onAddURL={this.addUrl}
+                    existingURLArray={this.state.urlArray!}
                 />                
                 <div id="logout">
                     <button

--- a/src/aws_s3_connect.tsx
+++ b/src/aws_s3_connect.tsx
@@ -153,7 +153,7 @@ export class UserS3 {
   }
 
   uploadFile = (url: string, bucketName: string, uniqueTime: string) => {
-    const r = axios
+    const resp = axios
       .get(encodeURI(url), {
         responseType: "arraybuffer",
         withCredentials: true,

--- a/src/aws_s3_file_transfer.tsx
+++ b/src/aws_s3_file_transfer.tsx
@@ -33,18 +33,21 @@ export class FileTransfer extends React.Component<Props, TableState>{
     constructor(props:Props){
         super(props);
         this.addRow = this.addRow.bind(this);
+        this.updateTable = this.updateTable.bind(this);
+        this.updateFromStorage = this.updateFromStorage.bind(this);
         this.state = {
             tableRows: [],
         };
+        this.updateFromStorage();
+    }
 
-        // Reconstruct state and the table on UI if there was a URL array in storage
+    // Update the table rows from what is stored in storage (Targets reconstructing this UI)
+    updateFromStorage = () => {
         const existingURLArray = this.props.existingURLArray;
-
         if(existingURLArray!.length > 0) {
             for (let url in existingURLArray){
                 const row : RowData = {data:url}
                 this.addRow(row);
-                this.updateTable(row);
             }
         } 
     }
@@ -74,14 +77,15 @@ export class FileTransfer extends React.Component<Props, TableState>{
         // Necessary to avoid duplicate file names being sent to bucket. 
         // This will need to be changed for robustness when naming files
         let dateTime = new Date()
-
         s3Client.uploadFile(fileURL, s3Client.whichBucket, dateTime.toString());
 
         // Show the user whether a succesful transfer happened and log it in state
         this.addRow(row);
-        this.updateTable(row);
     };
 
+    // STALE FUNCTION
+    // Keeping it here because it might be of use when dealing with status of files sent 
+    // NEW Implementation: Rows are rendered from memory brought by the App
     // Updates the table on UI to show the user the new file trying to be sent
     updateTable = (newRowData:RowData) => {
         const tbodyRef = document.getElementById('filesSentTable')!.getElementsByTagName('tbody')[0];
@@ -101,7 +105,6 @@ export class FileTransfer extends React.Component<Props, TableState>{
         const unknown = document.createTextNode("unknown");
         statusCell.appendChild(unknown);
     }
-
 
     render () {
         return(
@@ -138,7 +141,16 @@ export class FileTransfer extends React.Component<Props, TableState>{
                                     <th id="tableHeader">File URL</th>
                                     <th id="tableHeader">Status</th>
                             </thead>
-                            <tbody id="body"></tbody>
+                            <tbody id="body">
+                                {this.props.existingURLArray?.map(row => {
+                                    return (
+                                        <tr>
+                                            <td>{row}</td>
+                                            <td>{"unknown"}</td>
+                                        </tr>
+                                    )
+                                })}
+                            </tbody>
                         </table>
                     </div>
                 </form>

--- a/src/aws_s3_file_transfer.tsx
+++ b/src/aws_s3_file_transfer.tsx
@@ -14,6 +14,8 @@ type Props = {
   onViewChange? : (s:string)=>void,
   onS3ObjChange? : (o:UserS3)=>void,
   existingS3Obj? : UserS3
+  onAddURL? : (u:string)=>void
+  existingURLArray? : Array<string>
 };
 
 // Store all data relavent to a row for the table (URL,success status, trash)
@@ -34,6 +36,17 @@ export class FileTransfer extends React.Component<Props, TableState>{
         this.state = {
             tableRows: [],
         };
+
+        // Reconstruct state and the table on UI if there was a URL array in storage
+        const existingURLArray = this.props.existingURLArray;
+
+        if(existingURLArray!.length > 0) {
+            for (let url in existingURLArray){
+                const row : RowData = {data:url}
+                this.addRow(row);
+                this.updateTable(row);
+            }
+        } 
     }
 
     // Adds the new row's data to state
@@ -49,6 +62,9 @@ export class FileTransfer extends React.Component<Props, TableState>{
 
         // URL for the file inputted
         const fileURL = target.fileURL.value;
+
+        // Add URL to state and storage
+        this.props.onAddURL!(fileURL);
 
         // This will need to be expanded to support URL validation (success column)
         const row: RowData = {data:fileURL}

--- a/src/storage/store_url_array.ts
+++ b/src/storage/store_url_array.ts
@@ -1,9 +1,9 @@
 // Global key for accessing Array of URLs
 const URL_KEY = 'urlKey';
 
-export class URLStorage
-{
-    //Gets URL array from memory, pushes link, and stores the updated Array
+export class URLStorage{
+    
+    // Gets URL array from memory, pushes link, and stores the updated Array
     static putURL(url:string){
         chrome.storage.session.get([URL_KEY], function(result) {
             let urlArray = result[URL_KEY] ?? [];
@@ -13,14 +13,14 @@ export class URLStorage
         });
     }
 
-    //Retrieves URL Array from memory
+    // Retrieves URL Array from memory
     static getURLArray(onGetStorageKeyValue:(a:Array<string>)=>void) {
         chrome.storage.session.get([URL_KEY], function(result) {
             onGetStorageKeyValue(result[URL_KEY]);
         });
     }
 
-    //Clears URLs from URL array
+    // Clears URLs from URL array
     static removeURLArray(onGetStorageKeyValue:()=>void){
         chrome.storage.session.remove([URL_KEY], function() {
             onGetStorageKeyValue();


### PR DESCRIPTION
PR adds persistence to file transfer UI, links are now rendered from what is in storage (including when reconstructing the UI). 

It also supports right clicked links - links clicked on from the context menu will be rendered in the table.



Resolves #63 

