### PR TITLE
Fix table overflows

### DIFF
--- a/src/aws_s3_file_transfer.tsx
+++ b/src/aws_s3_file_transfer.tsx
@@ -138,8 +138,8 @@ export class FileTransfer extends React.Component<Props, TableState>{
                     <div id="filesSentTable">
                         <table id="table">
                             <thead>
-                                    <th id="tableHeader">File URL</th>
-                                    <th id="tableHeader">Status</th>
+                                    <th id="urlID">File URL</th>
+                                    <th id="statusID">Status</th>
                             </thead>
                             <tbody id="body">
                                 {this.props.existingURLArray?.map(row => {

--- a/src/index.html
+++ b/src/index.html
@@ -134,15 +134,30 @@
         }
 
         table {
+            table-layout:fixed; 
             border-collapse: collapse;
             width: 100%;
+            height: 20px;
+            overflow: scroll;
         }
 
         td {
+            display: table-cell;
             font-size: 14px;
+            width: 100%;
+            height: 20px;
+            overflow: scroll;
         }
 
-        #tableHeader {
+        #urlID {
+            width: 80%;
+            color: rgb(70, 163, 175);
+            font-weight: 600;
+            font-size: 16px;
+        }
+
+        #statusID {
+            width:20%;
             color: rgb(70, 163, 175);
             font-weight: 600;
             font-size: 16px;


### PR DESCRIPTION
PR fixes issue where a massive url would alter the dimensions of the table columns and overflow into the status column. Any content that would have overflowed now can be viewed by using the scroll bar


<img width="521" alt="Screen Shot 2023-04-18 at 10 01 48 PM" src="https://user-images.githubusercontent.com/62078498/232947288-90c8ebae-b286-4769-9b35-e2d6e5bb1d6f.png">
